### PR TITLE
Enable "debian" crossed with RHEL

### DIFF
--- a/config/lyrical/test_cases/tutorial_party.yaml
+++ b/config/lyrical/test_cases/tutorial_party.yaml
@@ -105,10 +105,6 @@ test_cases_builders:
           all_labels: [zenoh, binary]
           negate: false
       - !Exclude
-          all_labels: ['rhel 10', debian]
-          # No debian packages on Windows
-          negate: false
-      - !Exclude
           all_labels: [windows, debian]
           # No debian packages on Windows
           negate: false


### PR DESCRIPTION
Removed exclusion for 'rhel 10' and 'debian' labels.


### Did you use Generative AI?
No

### Additional Information

[#Lyrical Luth testing party > RHEL build type for RPM](https://openrobotics.zulipchat.com/#narrow/channel/594223-Lyrical-Luth-testing-party/topic/RHEL.20build.20type.20for.20RPM/with/593110193)